### PR TITLE
Use default GitHub Action runners

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   checks:
     name: Build and check
-    runs-on: linux-x64-ubuntu-latest-4cpu-16gb-150gb
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   changesets:
     name: Changesets
-    runs-on: linux-x64-ubuntu-latest-4cpu-16gb-150gb
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.changesets-result.outputs.version }}
       should-deploy: ${{ steps.changesets-result.outputs.should-deploy }}


### PR DESCRIPTION
Use default GitHub Action runners so that the repository's visibility can be set back to `public`.